### PR TITLE
feat(signals): Implement mock trading signal service and endpoint  

### DIFF
--- a/apps/backend/src/interfaces/trading-signal.interface.ts
+++ b/apps/backend/src/interfaces/trading-signal.interface.ts
@@ -1,0 +1,12 @@
+export interface TradingSignal {
+    signal_id: string
+    timestamp: string
+    token_pair: string
+    sentiment_score: number
+    liquidity_usd: number
+    volume_usd: number
+    category: string
+    thesis: string
+    recommendation: string
+  }
+  

--- a/apps/backend/src/signals/http/getMockSignal.http
+++ b/apps/backend/src/signals/http/getMockSignal.http
@@ -1,0 +1,1 @@
+GET  http://localhost:3000/signals/mock 

--- a/apps/backend/src/signals/mock-signals.service.spec.ts
+++ b/apps/backend/src/signals/mock-signals.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockSignalsService } from '../../../signals/mock-signals.service';
+
+describe('MockSignalsService', () => {
+  let service: MockSignalsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MockSignalsService],
+    }).compile();
+
+    service = module.get<MockSignalsService>(MockSignalsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/signals/mock-signals.service.ts
+++ b/apps/backend/src/signals/mock-signals.service.ts
@@ -1,6 +1,29 @@
 import { Injectable } from "@nestjs/common"
+import { TradingSignal } from "src/interfaces/trading-signal.interface"
 @Injectable()
 export class MockSignalService {
- 
+  generateMockSignals(): TradingSignal[] {
+    const tokenPairs = ["BTC/USD", "ETH/USD", "SOL/USD", "AVAX/USD", "DOT/USD"]
+    const categories = ["high-confidence", "medium-confidence", "low-confidence"]
+    const recommendations = ["buy", "sell", "hold"]
+
+    return Array.from({ length: 5 }, (_, i) => {
+      // Generate a random date within the last week
+      const date = new Date()
+      date.setDate(date.getDate() - Math.floor(Math.random() * 7))
+
+      return {
+        signal_id: `sig_mock_00${i + 1}`,
+        timestamp: date.toISOString(),
+        token_pair: tokenPairs[Math.floor(Math.random() * tokenPairs.length)],
+        sentiment_score: Number.parseFloat((Math.random() * 2 - 1).toFixed(2)), // Range from -1 to 1
+        liquidity_usd: Math.floor(Math.random() * 5000000) + 500000, // Range from 500K to 5.5M
+        volume_usd: Math.floor(Math.random() * 1000000) + 100000, // Range from 100K to 1.1M
+        category: categories[Math.floor(Math.random() * categories.length)],
+        thesis: `This is a mock thesis for signal ${i + 1}. The market conditions suggest this action based on technical analysis and market sentiment.`,
+        recommendation: recommendations[Math.floor(Math.random() * recommendations.length)],
+      }
+    })
+  }
 }
 

--- a/apps/backend/src/signals/mock-signals.service.ts
+++ b/apps/backend/src/signals/mock-signals.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from "@nestjs/common"
+@Injectable()
+export class MockSignalService {
+ 
+}
+

--- a/apps/backend/src/signals/signals.controller.ts
+++ b/apps/backend/src/signals/signals.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Get } from '@nestjs/common';
 import { SignalsService } from './signals.service';
-
 @Controller('signals')
 export class SignalsController {
-  constructor(private readonly signalsService: SignalsService) {}
+  constructor(
+    private readonly signalsService: SignalsService,
+  ) {}
 
   @Get()
   findAll() {
     return this.signalsService.findAll();
   }
+
 }
+
+

--- a/apps/backend/src/signals/signals.controller.ts
+++ b/apps/backend/src/signals/signals.controller.ts
@@ -1,9 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { SignalsService } from './signals.service';
+import { MockSignalService } from './mock-signals.service';
+import { TradingSignal } from 'src/interfaces/trading-signal.interface';
+
 @Controller('signals')
 export class SignalsController {
   constructor(
     private readonly signalsService: SignalsService,
+    private readonly mockSignalsService: MockSignalService
   ) {}
 
   @Get()
@@ -11,6 +15,10 @@ export class SignalsController {
     return this.signalsService.findAll();
   }
 
+  @Get('mock')
+  getMockSignals(): TradingSignal[] {
+    return this.mockSignalsService.generateMockSignals();
+  }
 }
 
 

--- a/apps/backend/src/signals/signals.module.ts
+++ b/apps/backend/src/signals/signals.module.ts
@@ -5,5 +5,6 @@ import { SignalsController } from './signals.controller';
 @Module({
   controllers: [SignalsController],
   providers: [SignalsService],
+  exports: [SignalsService]
 })
 export class SignalsModule {}

--- a/apps/backend/src/signals/signals.module.ts
+++ b/apps/backend/src/signals/signals.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SignalsService } from './signals.service';
 import { SignalsController } from './signals.controller';
+import { MockSignalService } from './mock-signals.service';
 
 @Module({
   controllers: [SignalsController],
-  providers: [SignalsService],
-  exports: [SignalsService]
+  providers: [SignalsService, MockSignalService],
+  exports: [SignalsService, MockSignalService]
 })
 export class SignalsModule {}


### PR DESCRIPTION
- Created Trading-signal Interface.  
- Created MockSignalGenerator to handle signal generation logic.  
- Added MockSignalService to produce an array of trading signals.  
- Implemented SignalsController to expose /signals/mock endpoint.  
- Set up dependency injection and modular architecture for scalability.  
- Testing the getMockSIgnal endpoint; see screenshot attached;
![Screenshot (32)](https://github.com/user-attachments/assets/23668280-58a5-4348-9dfb-1f1722c87cdc)
